### PR TITLE
Allow configuration of listening IP address, allowed hosts etc.

### DIFF
--- a/files/spamassassin-default
+++ b/files/spamassassin-default
@@ -1,8 +1,0 @@
-## This file is being maintained by Puppet
-## DO NOT EDIT
-
-ENABLED=1
-OPTIONS="--create-prefs --max-children 5 --helper-home-dir --allow-tell \
-         --listen-ip=127.0.0.1 --allowed-ips=127.0.0.1 -u debian-spamd"
-PIDFILE="/var/run/spamd.pid"
-CRON=1

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,7 +2,13 @@
 #
 # This module manages spamassassin
 #
-class spamassassin {
+class spamassassin(
+  $listenip = '127.0.0.1',
+  $allowedips = '127.0.0.1',
+  $helperhomedir = '',
+  $nouserconfig = false,
+  $allowtell = false
+) {
   case $::osfamily {
     RedHat: {
       $package_list = [
@@ -43,7 +49,7 @@ class spamassassin {
 
   if $::osfamily == 'Debian' {
     file { '/etc/default/spamassassin':
-      source  => 'puppet:///modules/spamassassin/spamassassin-default',
+      content => template('spamassassin/spamassassin-default'),
       require => Package['spamassassin'],
       notify  => Service['spamassassin'],
     }

--- a/templates/spamassassin-default
+++ b/templates/spamassassin-default
@@ -1,0 +1,14 @@
+## This file is being maintained by Puppet
+## DO NOT EDIT
+
+ENABLED=1
+OPTIONS="--create-prefs \
+         --max-children 5 \
+         --helper-home-dir=<%= @helperhomedir %> \
+         --listen-ip=<%= @listenip %> \
+         --allowed-ips=<%= @allowedips %> \
+         --username=debian-spamd<% if @nouserconfig %> \
+         --nouser-config<% end %><% if @allowtell %> \
+         --allow-tell<% end %>"
+PIDFILE="/var/run/spamd.pid"
+CRON=1


### PR DESCRIPTION
This is needed to connect to spamd from other hosts (e.g. spamc connecting to spamd running on a separate machine). Add some support for some additional command line options.
